### PR TITLE
Support postcss-style-guide v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psg-theme-1column",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "1 column theme of postcss-style-guide",
   "keywords": [
     "psg-theme",

--- a/template.ejs
+++ b/template.ejs
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <title><%= projectName %></title>
-        <style><%- codeStyle %><%- tmplStyle %><%- css %></style>
+        <style><%- codeStyle %><%- tmplStyle %><%- rootStyle %><%- processedCSS %></style>
     </head>
     <body>
         <header class="docs-header">


### PR DESCRIPTION
I updated postcss-style-guide, so we must change assigned variables in `template.ejs`.

If you merge this PR, run `npm publish`.
